### PR TITLE
Add support and privacy policy links

### DIFF
--- a/app/(main)/settings.tsx
+++ b/app/(main)/settings.tsx
@@ -454,13 +454,26 @@ export default function SettingsScreen() {
             {/* Customer Support */}
             <TouchableOpacity 
               style={styles.settingItem}
-              onPress={() => Linking.openURL('mailto:support@antigambling.app')}
+              onPress={() => Linking.openURL('https://tryunbet.com/support.html')}
             >
               <View style={styles.settingItemContent}>
                 <View style={styles.settingIcon}>
                   <Ionicons name="help-circle" size={24} color="#6B7280" />
                 </View>
                 <Text style={styles.settingText}>Customer Support Center</Text>
+              </View>
+            </TouchableOpacity>
+
+            {/* Privacy Policy */}
+            <TouchableOpacity 
+              style={styles.settingItem}
+              onPress={() => Linking.openURL('https://tryunbet.com/privacy.html')}
+            >
+              <View style={styles.settingItemContent}>
+                <View style={styles.settingIcon}>
+                  <Ionicons name="shield-checkmark" size={24} color="#6B7280" />
+                </View>
+                <Text style={styles.settingText}>Privacy Policy</Text>
               </View>
             </TouchableOpacity>
 

--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator, Alert, Linking } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useOAuth, useAuth } from '@clerk/clerk-expo';
 import { useRouter } from 'expo-router';
@@ -96,7 +96,13 @@ export default function AuthScreen() {
         </View>
 
         <Text style={styles.termsText}>
-          By continuing, you agree to our Terms & Privacy Policy
+          By continuing, you agree to our{' '}
+          <Text 
+            style={styles.termsLink}
+            onPress={() => Linking.openURL('https://tryunbet.com/privacy.html')}
+          >
+            Terms & Privacy Policy
+          </Text>
         </Text>
       </View>
     </SafeAreaView>
@@ -192,5 +198,9 @@ const styles = StyleSheet.create({
     color: 'rgba(255, 255, 255, 0.4)',
     textAlign: 'center',
     paddingHorizontal: 40,
+  },
+  termsLink: {
+    color: '#5B8DFF',
+    textDecorationLine: 'underline',
   },
 });

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, KeyboardAvoidingView, Platform, ScrollView, TextInput, Image, Dimensions, ActivityIndicator, Animated } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, KeyboardAvoidingView, Platform, ScrollView, TextInput, Image, Dimensions, ActivityIndicator, Animated, Linking } from 'react-native';
 
 // Conditionally import notifications - will fail in Expo Go
 let Notifications: any;
@@ -1125,7 +1125,15 @@ export default function Onboarding() {
               <Ionicons name="logo-apple" size={24} color="#FFFFFF" />
               <Text style={styles.authButtonText}>Continue with Apple</Text>
             </TouchableOpacity>
-            <Text style={styles.termsText}>By continuing, you agree to our Terms & Privacy Policy</Text>
+            <Text style={styles.termsText}>
+              By continuing, you agree to our{' '}
+              <Text 
+                style={styles.termsLink}
+                onPress={() => Linking.openURL('https://tryunbet.com/privacy.html')}
+              >
+                Terms & Privacy Policy
+              </Text>
+            </Text>
           </View>
         );
 
@@ -1932,6 +1940,10 @@ const styles = StyleSheet.create({
     opacity: 0.5,
     textAlign: 'center',
     marginTop: 20,
+  },
+  termsLink: {
+    color: '#5B8DFF',
+    textDecorationLine: 'underline',
   },
   // Success styles
   successContainer: {

--- a/core_app_onboarding/onboarding-2.tsx
+++ b/core_app_onboarding/onboarding-2.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, KeyboardAvoidingView, Platform, ScrollView, TextInput, Image, Dimensions, ActivityIndicator, Animated } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, KeyboardAvoidingView, Platform, ScrollView, TextInput, Image, Dimensions, ActivityIndicator, Animated, Linking } from 'react-native';
 import { useSignUp, useOAuth, useAuth as useClerkAuth } from '@clerk/clerk-expo';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -985,7 +985,15 @@ export default function Onboarding() {
               <Ionicons name="logo-apple" size={24} color="#FFFFFF" />
               <Text style={styles.authButtonText}>Continue with Apple</Text>
             </TouchableOpacity>
-            <Text style={styles.termsText}>By continuing, you agree to our Terms & Privacy Policy</Text>
+            <Text style={styles.termsText}>
+              By continuing, you agree to our{' '}
+              <Text 
+                style={styles.termsLink}
+                onPress={() => Linking.openURL('https://tryunbet.com/privacy.html')}
+              >
+                Terms & Privacy Policy
+              </Text>
+            </Text>
           </View>
         );
 
@@ -1768,6 +1776,10 @@ const styles = StyleSheet.create({
     opacity: 0.5,
     textAlign: 'center',
     marginTop: 20,
+  },
+  termsLink: {
+    color: '#5B8DFF',
+    textDecorationLine: 'underline',
   },
   // Success styles
   successContainer: {


### PR DESCRIPTION
## Summary
- Updated Customer Support link to use the new support page URL
- Added Privacy Policy as a new menu item in settings
- Made Terms & Privacy Policy text clickable across all authentication flows

## Changes
- **Settings page**: Updated support link from email to https://tryunbet.com/support.html
- **Settings page**: Added new Privacy Policy menu item with shield icon
- **Auth screen**: Made Terms & Privacy Policy text clickable
- **Onboarding screens**: Made Terms & Privacy Policy text clickable in both onboarding flows

## Test plan
- [ ] Tap Customer Support Center in settings - should open https://tryunbet.com/support.html
- [ ] Tap Privacy Policy in settings - should open https://tryunbet.com/privacy.html  
- [ ] Tap Terms & Privacy Policy text on auth screen - should open privacy policy
- [ ] Tap Terms & Privacy Policy text during onboarding - should open privacy policy

🤖 Generated with [Claude Code](https://claude.ai/code)