### PR TITLE
Fix streak timer for new accounts

### DIFF
--- a/app/(main)/(tabs)/index.tsx
+++ b/app/(main)/(tabs)/index.tsx
@@ -50,11 +50,6 @@ export default function HomeScreen() {
   const getStreakStartDate = () => {
     if (!user) return new Date();
     
-    // If user has no relapses, use recovery start date
-    if (!user.lastRelapseDate && user.recoveryStartDate) {
-      return new Date(user.recoveryStartDate);
-    }
-    
     // If user has relapsed, use day after last relapse
     if (user.lastRelapseDate) {
       const lastRelapse = new Date(user.lastRelapseDate);
@@ -62,7 +57,17 @@ export default function HomeScreen() {
       return lastRelapse;
     }
     
-    // Fallback to today
+    // If user has no relapses, use recovery start date (set when account created)
+    if (user.recoveryStartDate) {
+      return new Date(user.recoveryStartDate);
+    }
+    
+    // Final fallback: use account creation time
+    if (user._creationTime) {
+      return new Date(user._creationTime);
+    }
+    
+    // Last resort fallback
     return new Date();
   };
 


### PR DESCRIPTION
## Summary
- Fix home screen timer to start counting from account creation for new users
- Previously showed 0 time for new accounts, now shows proper streak from signup

## Changes
- Reorder streak calculation logic to prioritize recovery start date
- Add fallback to account creation time (_creationTime) if recovery start missing
- New accounts now see timer counting up from when they created account

## Logic Priority
1. **After relapse**: Day after `lastRelapseDate` 
2. **No relapses**: `recoveryStartDate` (set at account creation)
3. **Fallback**: Account `_creationTime`
4. **Last resort**: Current time

## Test plan
- [ ] Verify new accounts show timer counting from account creation
- [ ] Confirm existing users with relapses still work correctly
- [ ] Check users with custom recovery start dates are unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)