### PR TITLE
Configure app as iPhone-only

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,6 +15,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.peterwang.unbet",
+      "requireFullScreen": true,
       "infoPlist": {
         "NSUserTrackingUsageDescription": "This identifier will be used to deliver personalized ads to you.",
         "ITSAppUsesNonExemptEncryption": false,


### PR DESCRIPTION
## Summary
Configure the app to be iPhone-only by adding `requireFullScreen: true` to the iOS configuration.

## Changes
- Added `requireFullScreen: true` to iOS config in app.json
- This works together with the existing `supportsTablet: false` setting
- Ensures the app is distributed as iPhone-only on the App Store
- iPad screenshots are no longer required for App Store submission

## Test Plan
- [x] Verify app.json is valid
- [x] Confirm app builds successfully with this configuration
- [ ] Test on physical iPhone device to ensure full screen requirement works

🤖 Generated with [Claude Code](https://claude.ai/code)